### PR TITLE
Extend  compat for DocStringExtensions and relax test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
-DocStringExtensions = "0.8"
+DocStringExtensions = "0.8, 0.9"
 IterativeSolvers = "0.8, 0.9"
 LinearMaps = "2.6, 3.2"
 MLJModelInterface = "0.3, 0.4, 1.0"

--- a/test/interface/fitpredict.jl
+++ b/test/interface/fitpredict.jl
@@ -89,5 +89,9 @@ end
     mdl = LogisticClassifier()
     X, y = MLJBase.@load_iris
     mach = MLJBase.machine(mdl, X, y)
-    @test_logs (:info,"Training Machine{LogisticClassifier,…}.") (:info,"Solver: LBFGS()") MLJBase.fit!(mach; verbosity=1)
+    @test_logs(
+        (:info, r"LogisticClassifier"),
+        (:info, r"Solver: LBFGS()"),
+        MLJBase.fit!(mach; verbosity=1),
+    )
 end


### PR DESCRIPTION
A logging test has been invalidated by a change to `show` for machines in MLJBase. This PR relaxes the test and also bumps the compat for DocStringExtensions.jl