### PR TITLE
closes #129 by fixing the interface after #123

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJLinearModels"
 uuid = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -25,6 +25,7 @@ julia = "1.5"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
@@ -34,4 +35,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DelimitedFiles", "PyCall", "ForwardDiff", "Test", "Random", "RDatasets", "RCall", "MLJBase", "StableRNGs", "DataFrames"]
+test = ["DelimitedFiles", "PyCall", "ForwardDiff", "Test", "Random", "RDatasets", "RCall", "MLJ", "MLJBase", "StableRNGs", "DataFrames"]

--- a/test/interface/extras.jl
+++ b/test/interface/extras.jl
@@ -32,4 +32,14 @@ end
     y = MLJ.coerce(y_, MLJ.OrderedFactor);
     model = MultinomialClassifier()
     mach = MLJ.machine(model, X, y) |> MLJ.fit!
+    yhat = MLJ.predict_mode(mach, X)
+
+    # crappy "test" but we're just testing that predict works fine    
+    @test MLJ.misclassification_rate(yhat, y) < 0.4
+
+    model = LogisticClassifier()
+    mach = MLJ.machine(model, X, y) |> MLJ.fit!
+    yhat = MLJ.predict_mode(mach, X)
+
+    @test MLJ.misclassification_rate(yhat, y) < 0.4
 end

--- a/test/interface/extras.jl
+++ b/test/interface/extras.jl
@@ -24,3 +24,12 @@ end
     y = MLJBase.coerce(vcat(fill("a", 10), ["b", ]), MLJBase.Multiclass)[1:10]
     mach = MLJBase.machine(MultinomialClassifier(), X, y) |> MLJBase.fit!
 end
+
+# https://github.com/JuliaAI/MLJLinearModels.jl/issues/129
+@testset "Crabs" begin
+    data = MLJ.load_crabs()
+    y_, X = MLJ.unpack(data, ==(:sp), col->col in [:FL, :RW]);
+    y = MLJ.coerce(y_, MLJ.OrderedFactor);
+    model = MultinomialClassifier()
+    mach = MLJ.machine(model, X, y) |> MLJ.fit!
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using MLJLinearModels, Test, LinearAlgebra
 using Random, StableRNGs, DataFrames, ForwardDiff
-import MLJBase # not MLJModelInterface, to mimic the full interface
+import MLJ, MLJBase
 
 DO_COMPARISONS = false; include("testutils.jl")
 


### PR DESCRIPTION
PR #123  makes an explicit distinction between two cases:

1. binary classification with an explicit LogisticClassifier
2. binary classification with an explicit MultinomialClassifier

The way these things are processed is not the same. In short, the output of LC is a score corresponding to "class 1" (whatever it is), the score comes out of sigmoid ([logic](https://github.com/JuliaAI/MLJLinearModels.jl/blob/5bb7c6de3cfba78eeaab2e1efe851e8c4ef1fd4e/src/mlj/interface.jl#L90-L92)), whereas in the MN case it comes out of a softmax. 

Anyway long story short, the PR #123 was not properly finished (the `MLJ.fit` was fixed correctly but the `MLJ.predict` should have been fixed in basically the same way.