### PR TITLE
For a 0.8.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJLinearModels"
 uuid = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.7.2"
+version = "0.8.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ LinearMaps = "2.6, 3.2"
 MLJModelInterface = "0.3, 0.4, 1.0"
 Optim = "0.20, 0.21, 1"
 Parameters = "0.12"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -35,16 +35,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = [
-    "DelimitedFiles",
-    "PyCall",
-    "ForwardDiff",
-    "Test",
-    "Random",
-    "RDatasets",
-    "RCall",
-    "MLJ",
-    "MLJBase",
-    "StableRNGs",
-    "DataFrames",
-]
+test = ["DelimitedFiles", "PyCall", "ForwardDiff", "Test", "Random", "RDatasets", "RCall", "MLJ", "MLJBase", "StableRNGs", "DataFrames"]


### PR DESCRIPTION

For release notes:

- (**breaking**) Change the default value of the regularisation parameter `lambda` in `LogisticClassifier` from `1.0` to `eps()` (#131)