### PR TITLE
Fix MLJ docstrings

### DIFF
--- a/src/mlj/classifiers.jl
+++ b/src/mlj/classifiers.jl
@@ -65,7 +65,8 @@ See also [`MultinomialClassifier`](@ref).
     """some instance of `MLJLinearModels.S` where `S` is one of: `LBFGS`, `Newton`,
     `NewtonCG`, `ProxGrad`; but subject to the following restrictions:
 
-    - If `gamma > 0` (L1 norm penalized) then only `ProxGrad` is allowed.
+    - If `penalty = :l2`, `ProxGrad` is disallowed. Otherwise, `ProxyGrad` is the only
+      option.
 
     - Unless `scitype(y) <: Finite{2}` (binary target) `Newton` is disallowed.
 
@@ -141,7 +142,8 @@ See also [`LogisticClassifier`](@ref).
     """some instance of `MLJLinearModels.S` where `S` is one of: `LBFGS`,
     `NewtonCG`, `ProxGrad`; but subject to the following restrictions:
 
-    - If `gamma > 0` (L1 norm penalized) then `ProxGrad` is disallowed.
+    - If `penalty = :l2`, `ProxGrad` is disallowed. Otherwise, `ProxyGrad` is the only
+      option.
 
     - Unless `scitype(y) <: Finite{2}` (binary target) `Newton` is disallowed.
 

--- a/src/mlj/regressors.jl
+++ b/src/mlj/regressors.jl
@@ -323,11 +323,10 @@ See also [`HuberRegressor`](@ref), [`QuantileRegressor`](@ref).
     "whether to scale the penalty with the number of observations."
     scale_penalty_with_samples::Bool = true
     """some instance of `MLJLinearModels.S` where `S` is one of: `LBFGS`, `IWLSCG`,
-    `Newton`, `NewtonCG`, `ProxGrad`, unless `gamma > 0` (L1 norm penalized) in which
-    case only `ProxGrad` solvers are allowed.
+    `Newton`, `NewtonCG`, if `penalty = :l2`, and `ProxGrad` otherwise.
 
-    If `solver = nothing` (default) then `ProxGrad(accel=true)` (FISTA) is used,
-    unless `gamma = 0`, in which case `LBFGS()` is used.
+    If `solver = nothing` (default) then `LBFGS()` is used, if `penalty = :l2`, and
+    otherwise `ProxGrad(accel=true)` (FISTA) is used.
 
     Solver aliases: `FISTA(; kwargs...) = ProxGrad(accel=true, kwargs...)`,
     `ISTA(; kwargs...) = ProxGrad(accel=false, kwargs...)`"""
@@ -398,11 +397,10 @@ See also [`RobustRegressor`](@ref), [`QuantileRegressor`](@ref).
     "whether to scale the penalty with the number of observations."
     scale_penalty_with_samples::Bool = true
     """some instance of `MLJLinearModels.S` where `S` is one of: `LBFGS`, `IWLSCG`,
-    `Newton`, `NewtonCG`, `ProxGrad`, unless `gamma > 0` (L1 norm penalized) in which
-    case only `ProxGrad` solvers are allowed.
+    `Newton`, `NewtonCG`, if `penalty = :l2`, and `ProxGrad` otherwise.
 
-    If `solver = nothing` (default) then `ProxGrad(accel=true)` (FISTA) is used,
-    unless `gamma = 0`, in which case `LBFGS()` is used.
+    If `solver = nothing` (default) then `LBFGS()` is used, if `penalty = :l2`, and
+    otherwise `ProxGrad(accel=true)` (FISTA) is used.
 
     Solver aliases: `FISTA(; kwargs...) = ProxGrad(accel=true, kwargs...)`,
     `ISTA(; kwargs...) = ProxGrad(accel=false, kwargs...)`"""
@@ -473,11 +471,10 @@ See also [`RobustRegressor`](@ref), [`HuberRegressor`](@ref).
     "whether to scale the penalty with the number of observations."
     scale_penalty_with_samples::Bool = true
     """some instance of `MLJLinearModels.S` where `S` is one of: `LBFGS`, `IWLSCG`,
-    `ProxGrad`, unless `gamma > 0` (L1 norm penalized) in which case only
-    `ProxGrad` solvers are allowed.
+    if `penalty = :l2`, and `ProxGrad` otherwise.
 
-    If `solver = nothing` (default) then `ProxGrad(accel=true)` (FISTA) is used,
-    unless `gamma = 0`, in which case `LBFGS()` is used.
+    If `solver = nothing` (default) then `LBFGS()` is used, if `penalty = :l2`, and
+    otherwise `ProxGrad(accel=true)` (FISTA) is used.
 
     Solver aliases: `FISTA(; kwargs...) = ProxGrad(accel=true, kwargs...)`,
     `ISTA(; kwargs...) = ProxGrad(accel=false, kwargs...)`"""
@@ -553,11 +550,10 @@ $(example_docstring("LADRegressor"))
     "whether to scale the penalty with the number of observations."
     scale_penalty_with_samples::Bool = true
     """some instance of `MLJLinearModels.S` where `S` is one of: `LBFGS`, `IWLSCG`,
-    `ProxGrad`, unless `gamma > 0` (L1 norm penalized) in which case only
-    `ProxGrad` solvers are allowed.
+    if `penalty = :l2`, and `ProxGrad` otherwise.
 
-    If `solver = nothing` (default) then `ProxGrad(accel=true)` (FISTA) is used,
-    unless `gamma = 0`, in which case `LBFGS()` is used.
+    If `solver = nothing` (default) then `LBFGS()` is used, if `penalty = :l2`, and
+    otherwise `ProxGrad(accel=true)` (FISTA) is used.
 
     Solver aliases: `FISTA(; kwargs...) = ProxGrad(accel=true, kwargs...)`,
     `ISTA(; kwargs...) = ProxGrad(accel=false, kwargs...)`"""


### PR DESCRIPTION
In making #138 I overlooked that fact that solver switching is not based on the literal value of `gamma` but on the value of the `penalty` parameter (taking values `:l1`, `:l2`, and `:en`) which I had completely overlooked. This PR addresses this mistake and makes further changes to address the observation made [here](https://github.com/JuliaAI/MLJLinearModels.jl/issues/140#issuecomment-1412831060).