### PR TITLE
Fixes for quantile regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          RUN_COMPARISONS: "false"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJLinearModels"
 uuid = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJLinearModels"
 uuid = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/fit/solvers.jl
+++ b/src/fit/solvers.jl
@@ -46,11 +46,14 @@ Newton solver. This is a full Hessian solver and should be avoided for
 `newton_options` are the [options of Newton's method](https://julianlsolvers.github.io/Optim.jl/stable/#algo/newton/)
 
 ## Example
+
 ```julia
 using MLJLinearModels, Optim
 
-solver = MLJLinearModels.Newton(optim_options = Optim.Options(time_limit = 20),
-                                newton_options = (linesearch = Optim.LineSearches.HagerZhang()),))
+solver = MLJLinearModels.Newton(
+    optim_options = Optim.Options(time_limit = 20),
+    newton_options = (linesearch = Optim.LineSearches.HagerZhang()),)
+)
 ```
 """
 @with_kw struct Newton{O,S} <: Solver
@@ -70,13 +73,15 @@ generally be preferred for larger scale cases.
 `newtoncg_options` are the [options of Krylov Trust Region method](https://github.com/JuliaNLSolvers/Optim.jl/blob/master/src/multivariate/solvers/second_order/krylov_trust_region.jl)
 
 ## Example
+
 ```julia
 using MLJLinearModels, Optim
 
-solver = MLJLinearModels.Newton(optim_options = Optim.Options(time_limit = 20),
-                                newtoncg_options = (eta = 0.2,))
+solver = MLJLinearModels.NewtonCG(
+    optim_options = Optim.Options(time_limit = 20),
+    newtoncg_options = (eta = 0.2,)
+)
 ```
-
 """
 @with_kw struct NewtonCG{O,S} <: Solver
     optim_options::O = Optim.Options(f_tol=1e-4)
@@ -95,8 +100,10 @@ LBFGS quasi-Newton solver. See [the wikipedia entry](https://en.wikipedia.org/wi
 ```julia
 using MLJLinearModels, Optim
 
-solver = MLJLinearModels.Newton(optim_options = Optim.Options(time_limit = 20),
-                                lbfgs_options = (linesearch = Optim.LineSearches.HagerZhang()),))
+solver = MLJLinearModels.LBFGS(
+    optim_options = Optim.Options(time_limit = 20),
+    lbfgs_options = (linesearch = Optim.LineSearches.HagerZhang()),)
+)
 ```
 """
 @with_kw struct LBFGS{O,S} <: Solver

--- a/src/mlj/regressors.jl
+++ b/src/mlj/regressors.jl
@@ -104,7 +104,7 @@ See also [`ElasticNetRegressor`](@ref).
     "whether to scale the penalty with the number of observations."
     scale_penalty_with_samples::Bool = true
     """any instance of `MLJLinearModels.Analytical`. Use `Analytical()` for
-    Cholesky and `CG()=Analytical(iteration=true)` for conjugate-gradient.
+    Cholesky and `CG()=Analytical(iterative=true)` for conjugate-gradient.
     If `solver = nothing` (default) then `Analytical()` is used. """
     solver::Option{Solver}   = nothing
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/test/benchmarks/elementary_functions.jl
+++ b/test/benchmarks/elementary_functions.jl
@@ -1,6 +1,6 @@
 using MLJLinearModels
 using BenchmarkTools, Random, LinearAlgebra
-DO_COMPARISONS = false; include("../testutils.jl")
+include("../testutils.jl")
 
 n, p = 50_000, 500
 ((X, y, θ), (X1, y1, θ1)) = generate_continuous(n, p;  seed=512, sparse=0.5)

--- a/test/benchmarks/logistic-multinomial.jl
+++ b/test/benchmarks/logistic-multinomial.jl
@@ -1,6 +1,6 @@
 using MLJLinearModels
 using BenchmarkTools, Random, LinearAlgebra
-DO_COMPARISONS = false; include("../testutils.jl")
+include("../testutils.jl")
 
 n, p = 50_000, 500
 ((X, y, θ), (X1, y1, θ1)) = generate_binary(n, p; seed=525)

--- a/test/benchmarks/ridge-lasso.jl
+++ b/test/benchmarks/ridge-lasso.jl
@@ -1,6 +1,6 @@
 using MLJLinearModels, StableRNGs
 using BenchmarkTools, Random, LinearAlgebra
-DO_COMPARISONS = false; include("../testutils.jl")
+include("../testutils.jl")
 
 n, p = 50_000, 500
 ((X, y, θ), (X1, y1, θ1)) = generate_continuous(n, p;  seed=512, sparse=0.5)

--- a/test/benchmarks/robust.jl
+++ b/test/benchmarks/robust.jl
@@ -1,0 +1,29 @@
+# Follow up from issue #147 comparing quantreg more specifically.
+
+if DO_COMPARISONS
+    @testset "Comp-QR-147" begin
+        using CSV, DataFrames
+
+        dataset = CSV.read(download("http://freakonometrics.free.fr/rent98_00.txt"), DataFrame)
+        tau     = 0.3
+
+        y  = Vector(dataset[!,:rent_euro])
+        X  = Matrix(dataset[!,[:area, :yearc]])
+        X1 = hcat(X[:,1], X[:, 2], ones(size(X, 1)))
+
+        qr  = QuantileRegression(tau; penalty=:none)
+        obj = objective(qr, X, y)
+
+        θ_lbfgs = fit(qr, X, y)
+        @test isapprox(obj(θ_lbfgs), 226_639, rtol=1e-4)
+
+        # in this case QR with BR method does better
+        θ_qr_br = rcopy(getproperty(QUANTREG, :rq_fit_br)(X1, y; tau=tau))[:coefficients]
+        @test isapprox(obj(θ_qr_br), 207_551, rtol=1e-4)
+
+        # lasso doesn't
+        θ_qr_lasso = rcopy(getproperty(QUANTREG, :rq_fit_lasso)(X1, y; tau=tau))[:coefficients]
+        obj(θ_qr_lasso) # 229_172
+        @test 228_000 ≤ obj(θ_qr_lasso) ≤ 231_000
+    end
+end

--- a/test/loss-penalty/robust.jl
+++ b/test/loss-penalty/robust.jl
@@ -5,7 +5,7 @@ y = randn(rng, 10)
 r = x .- y
 
 @testset "Robust Loss" begin
-    δ = 0.5
+    δ = 0.75
     rlδ = RobustLoss(Huber(δ))
     @test rlδ isa RobustLoss{HuberRho{δ}}
     @test rlδ(r) == rlδ(x, y) == sum(ifelse(abs(rᵢ)≤δ, rᵢ^2/2, δ*(abs(rᵢ)-δ/2)) for rᵢ in r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ using Random, StableRNGs, DataFrames, ForwardDiff
 import Optim
 import MLJ, MLJBase
 
-DO_COMPARISONS = false; include("testutils.jl")
+DO_COMPARISONS = true
+include("testutils.jl")
 
 m("UTILS"); include("utils.jl")
 
@@ -30,4 +31,8 @@ m("MLJ", false); begin
     mm("metadata");    include("interface/meta.jl")
     mm("fit-predict"); include("interface/fitpredict.jl")
     mm("extras");      include("interface/extras.jl")
+end
+
+m("MISC", false); begin
+    mm("benchmarks"); include("benchmarks/robust.jl")
 end


### PR DESCRIPTION
Out of convenience, MLJLM defines residuals as $X\theta - y$, however the literature typically does the opposite. This matters only if the loss is asymmetrical which is the case for the pinball loss used in the quantile regression. The report in #147 exposed this.

Note that the report in #147 also compared the performance of an IP method with the result obtained by MLJLM. The objective achieved using MLJLM is about 9% worse than that from the IP method. When using a non-IP method from the quantreg package, the objective function is 1-2% better. This is not worrying per se, in the case presented LBFGS just stops at a non-optimal point, likely gets stuck in a very flat zone.